### PR TITLE
Remove unnecessary frame, fixing Material Design In XAML demo

### DIFF
--- a/XamlDisplayer/CodeDisplayer/XamlDisplayerHost.cs
+++ b/XamlDisplayer/CodeDisplayer/XamlDisplayerHost.cs
@@ -7,9 +7,8 @@ using System.Windows.Controls;
 using System.Windows.Navigation;
 
 namespace CodeDisplayer {
-    public class XamlDisplayerHost : Frame{
-        public XamlDisplayerHost() {
-            this.NavigationUIVisibility = NavigationUIVisibility.Hidden;
-        }
+    public class XamlDisplayerHost : ContentControl
+    {
+        
     }
 }

--- a/XamlDisplayer/Demo/MainWindow.xaml.cs
+++ b/XamlDisplayer/Demo/MainWindow.xaml.cs
@@ -19,7 +19,7 @@ namespace DisplayXamlDemo {
     public partial class MainWindow : Window {
         public MainWindow() {
             InitializeComponent();
-            XamlDisplayerHost.Navigate(new Page1());
+            
         }
     }
 


### PR DESCRIPTION
Used a basic content control.  The frame served no purpose and is forcing text Foreground to black in all scenarios.